### PR TITLE
Add missing include for WebP/MSVC

### DIFF
--- a/src/gd_webp.c
+++ b/src/gd_webp.c
@@ -16,6 +16,7 @@
 #include "gd.h"
 #include "gd_errors.h"
 #include "gdhelpers.h"
+#include "gd_intern.h"
 
 #ifdef HAVE_LIBWEBP
 #include "webp/decode.h"


### PR DESCRIPTION
`gd_webp.c` needs `ssize_t` which is defined in `gd_intern.h` for MSVC.
(Other C files which use this type include this header, too.)

Fixes this error:
~~~
FAILED: src/CMakeFiles/libgd_static.dir/gd_webp.c.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1433~1.316\bin\Hostx64\x64\cl.exe   -DBGDWIN32 -DHAVE_CONFIG_H -DMSWIN32 -DNONDLL=1 -DWIN32 -DWINVER=0x0500 -D_CRT_SECURE_NO_DEPRECATE -D_WIN32 -D_WIN32_IE=0x0600 -D_WIN32_WINNT=0x0500 -ID:\buildtrees\libgd\src\1819764bdc-319f487d20.clean\src -ID:\buildtrees\libgd\x64-windows-static-dbg -ID:\buildtrees\libgd\x64-windows-static-dbg\src -ID:\buildtrees\libgd\src\1819764bdc-319f487d20.clean\before -external:ID:\installed\x64-windows-static\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /MP  /D_DEBUG /MTd /Z7 /Ob0 /Od /RTC1 /showIncludes /Fosrc\CMakeFiles\libgd_static.dir\gd_webp.c.obj /Fdsrc\CMakeFiles\libgd_static.dir\libgd_static.pdb /FS -c D:\buildtrees\libgd\src\1819764bdc-319f487d20.clean\src\gd_webp.c
D:\buildtrees\libgd\src\1819764bdc-319f487d20.clean\src\gd_webp.c(108): error C2065: 'ssize_t': undeclared identifier
~~~